### PR TITLE
Fix off-by-one error in lightmap generation

### DIFF
--- a/js/source-lightmap.js
+++ b/js/source-lightmap.js
@@ -96,7 +96,7 @@ var SourceLightmap = Object.create(Object, {
                 for(var j = 0; j < styleCount; ++j) {
                     var lightOffset = face.lightofs + (byteCount*j);
                     var lightbuffer = lighting.subarray(lightOffset, lightOffset + byteCount);
-                    var expbuffer = lightingExp.subarray(lightOffset + 3, lightOffset + byteCount - 3);
+                    var expbuffer = lightingExp.subarray(lightOffset + 3, lightOffset + byteCount);
                     
                     var i = 0;
                     


### PR DESCRIPTION
Here's another small fix for you. The last pixel in each lightmap was getting cut off, and then the clamping was turning the undefined/NaNs into zeros.
